### PR TITLE
SAGE-1300: add USB serial number validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@
 
 After installing the ∫Debian package the service will automatically run and fail as the default sync device is `/dev/dummy`. To enable the service to sync to the desired external media the **following** steps need to be taken:
 
-1. edit the `SYNC_DRIVE` variable in the `/etc/waggle/upload-sync.env` file to the external media (ex. `/dev/sdb2`) path
-2. wait for the service to auto-run or force the service to start via `systemctl start waggle-upload-sync.service`
+1. edit the `SYNC_DRIVE` variable in the `/etc/waggle/upload-sync.env` file to the desired external media (ex. `/dev/sdb2`) partition
+2. edit the `SYNC_USB_SERIAL` variable to the USB devices serial number (ex. `0376020100005389`)
+3. wait for the service to auto-run or force the service to start via `systemctl start waggle-upload-sync.service`
+
+>*Note*: you can discover the USB devices serial number by looking through the journal log when the USB device is inserted (i.e `journalctl -f`) and searching for `usb` and/or `SerialNumber:` logs
 
 >*Note*: you can see the logs for the service via `journalctl -fu waggle-upload-sync`
 

--- a/ROOTFS/etc/waggle/upload-sync.env
+++ b/ROOTFS/etc/waggle/upload-sync.env
@@ -2,3 +2,4 @@ SYNC_SOURCE=/media/plugin-data/uploads/
 SYNC_MOUNT=/tmp/upload-sync/
 SYNC_DST=uploads/
 SYNC_DRIVE=/dev/dummy
+SYNC_USB_SERIAL=dummyvalue

--- a/ROOTFS/usr/bin/waggle_upload_sync.sh
+++ b/ROOTFS/usr/bin/waggle_upload_sync.sh
@@ -18,29 +18,44 @@ if ! lsblk ${SYNC_DRIVE}; then
     exit 1
 fi
 
+# check if the drive matches the USB (by serial)
+found=
+for dev in /dev/disk/by-id/*; do
+    if echo $dev | grep -q ${SYNC_USB_SERIAL}; then
+        if [ "$(readlink -f $dev)" == "${SYNC_DRIVE}" ]; then
+            echo "Device [$SYNC_DRIVE] enumerated from [${dev}]"
+            found=1
+        fi
+    fi
+done
+if [ -z "${found}" ]; then
+    echo "ERROR: Unable to match USB serial [${SYNC_USB_SERIAL}] to device [${SYNC_DRIVE}]"
+    exit 2
+fi
+
 # create the temp mount point
 if ! mkdir -p ${SYNC_MOUNT}; then
     echo "ERROR: failed to create mount point [${SYNC_MOUNT}]"
-    exit 2
+    exit 3
 fi
 
 # mount the drive
 if ! mount ${SYNC_DRIVE} ${SYNC_MOUNT}; then
     echo "ERROR: failed to mount drive [${SYNC_DRIVE} ${SYNC_MOUNT}]"
-    exit 3
+    exit 4
 fi
 trap cleanup EXIT
 
 # validate the mount
 if ! mountpoint ${SYNC_MOUNT}; then
     echo "ERROR: failed to verify mountpoint [${SYNC_MOUNT}]"
-    exit 4
+    exit 5
 fi
 
 # create the mount uploads folder
 if ! mkdir -p ${rsync_dest}; then
     echo "ERROR: unable to create mount uploads folder [${rsync_dest}]"
-    exit 5
+    exit 6
 fi
 
 # execute rsync


### PR DESCRIPTION
Ensure that the USB serial device it mounted as the SYNC_DRIVE to prevent
accident syncing to the wrong partition.